### PR TITLE
Migrate set-output command to output file

### DIFF
--- a/buildx-pull/action.yml
+++ b/buildx-pull/action.yml
@@ -84,5 +84,5 @@ runs:
             buildx_opts="${buildx_opts} --cache-from=${cache}"
           fi
         done
-        echo "::set-output name=buildx-opts::${buildx_opts}"
+        echo "buildx-opts=${buildx_opts}" >> ${GITHUB_OUTPUT}
         echo "${buildx_opts}"


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/