### PR TITLE
Rollback types/node to v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@actions/core": "1.10.0"
   },
   "devDependencies": {
-    "@types/node": "18.0.6",
+    "@types/node": "16.18.2",
     "@vercel/ncc": "0.34.0",
     "eslint": "8.25.0",
     "prettier": "2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,10 +72,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@types/node@18.0.6":
-  version "18.0.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.6.tgz#0ba49ac517ad69abe7a1508bc9b3a5483df9d5d7"
-  integrity sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==
+"@types/node@16.18.2":
+  version "16.18.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.2.tgz#77878acc68c5f6241454008beedd39513bd8e851"
+  integrity sha512-KIGQJyya+opDCFvDSZMNNS899ov5jlNdtN7PypgHWeb8e+5vWISdwTRo/ClsNVlmDihzOGqFyNBDamUs7TQQCA==
 
 "@vercel/ncc@0.34.0":
   version "0.34.0"


### PR DESCRIPTION
Latest actions runner is using node 16