### PR TITLE
[ecr-push] Add push-multi-level-tags option

### DIFF
--- a/ecr-push/action.yml
+++ b/ecr-push/action.yml
@@ -39,25 +39,21 @@ runs:
         docker tag \
           ${{ inputs.image }}:${{ inputs.src-tag }} \
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:${digest}
-        docker tag \
-          ${{ inputs.image }}:${{ inputs.src-tag }} \
-          ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:${{ inputs.dest-tag }}
         docker push \
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:${digest}
-        docker push \
-          ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:${{ inputs.dest-tag }}
-        if [ ${{ inputs.push-multi-level-tags }}=="true" ]; then
-          TAG=${{ inputs.dest-tag }}
-          while [ -n "${TAG%.*}" ]; do
-            docker tag \
-              ${{ inputs.image }}:${{ inputs.src-tag }} \
-              ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:"${TAG}"
-            docker push \
-              ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:"${TAG}"
-            TRIMMED_TAG="${TAG%.*}"
-            if [ "${TAG}" == "${TRIMMED_TAG}" ]; then
-              break
-            fi
-            TAG="${TRIMMED_TAG}"
-          done
-        fi
+        TAG=${{ inputs.dest-tag }}
+        while [ -n "${TAG}" ]; do
+          docker tag \
+            ${{ inputs.image }}:${{ inputs.src-tag }} \
+            ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:"${TAG}"
+          docker push \
+            ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:"${TAG}"
+          if [ ${{ inputs.push-multi-level-tags }}=="false" ]; then
+            break
+          fi
+          TRIMMED_TAG="${TAG%.*}"
+          if [ "${TAG}" == "${TRIMMED_TAG}" ]; then
+            break
+          fi
+          TAG="${TRIMMED_TAG}"
+        done

--- a/ecr-push/action.yml
+++ b/ecr-push/action.yml
@@ -48,7 +48,7 @@ runs:
             ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:"${TAG}"
           docker push \
             ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:"${TAG}"
-          if [ ${{ inputs.push-multi-level-tags }}=="false" ]; then
+          if [ ${{ inputs.push-multi-level-tags }} == "false" ]; then
             break
           fi
           TRIMMED_TAG="${TAG%.*}"

--- a/ecr-push/action.yml
+++ b/ecr-push/action.yml
@@ -48,6 +48,7 @@ runs:
             ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:"${TAG}"
           docker push \
             ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:"${TAG}"
+
           if [ ${{ inputs.push-multi-level-tags }} == "false" ]; then
             break
           fi

--- a/ecr-push/action.yml
+++ b/ecr-push/action.yml
@@ -17,6 +17,10 @@ inputs:
   dest-tag:
     description: Destination image tag
     required: true
+  push-multi-level-tags:
+    description: If true, create tags by repeatedly removing the dot and following from dest-tag
+    required: true
+    default: "false"
 runs:
   using: composite
   steps:
@@ -42,3 +46,18 @@ runs:
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:${digest}
         docker push \
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:${{ inputs.dest-tag }}
+        if [ ${{ inputs.push-multi-level-tags }}=="true" ]; then
+          TAG=${{ inputs.dest-tag }}
+          while [ -n "${TAG%.*}" ]; do
+            docker tag \
+              ${{ inputs.image }}:${{ inputs.src-tag }} \
+              ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:"${TAG}"
+            docker push \
+              ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image }}:"${TAG}"
+            TRIMMED_TAG="${TAG%.*}"
+            if [ "${TAG}" == "${TRIMMED_TAG}" ]; then
+              break
+            fi
+            TAG="${TRIMMED_TAG}"
+          done
+        fi

--- a/ecr-push/action.yml
+++ b/ecr-push/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: Destination image tag
     required: true
   push-multi-level-tags:
-    description: If true, create tags by repeatedly removing the dot and following from dest-tag
+    description: If true, create tags by repeatedly removing the dot and following from the dest-tag
     required: true
     default: "false"
 runs:

--- a/ecr-push/action.yml
+++ b/ecr-push/action.yml
@@ -51,6 +51,9 @@ runs:
           if [ ${{ inputs.push-multi-level-tags }} == "false" ]; then
             break
           fi
+          if [[ "${TAG}" == *-* ]]; then
+            break
+          fi
           TRIMMED_TAG="${TAG%.*}"
           if [ "${TAG}" == "${TRIMMED_TAG}" ]; then
             break


### PR DESCRIPTION
## Description
This option will allow us to push multiple images with trimmed tags per period.

## Expected behavior
If `image` is `IMAGE`, `dest-tag` is `vA.B.C.D` and `push-multi-level-tags` is `true`, images with below tags are pushed: 
- `IMAGE:vA.B.C.D`
- `IMAGE:vA.B.C`
- `IMAGE:vA.B`
- `IMAGE:vA`